### PR TITLE
Installing spatie event stats and scheduling weekly sign up stats 

### DIFF
--- a/app/Console/Commands/Reports/Weekly/SignupStatsReport.php
+++ b/app/Console/Commands/Reports/Weekly/SignupStatsReport.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Reports\Weekly;
+
+use App\Stats\SignupStats;
+use Illuminate\Console\Command;
+use Spatie\SlackAlerts\Facades\SlackAlert;
+
+final class SignupStatsReport extends Command
+{
+    protected $signature = 'reports:signups';
+
+    protected $description = 'Check the statistics for the last weeks signups';
+
+    public function handle(): void
+    {
+        $stats = SignupStats::query()
+            ->start(now()->subWeek())
+            ->end(now())
+            ->get();
+
+        SlackAlert::blocks([
+            [
+                "type" => "section",
+                "text" => [
+                    "type" => "mrkdwn",
+                    "text" => 'You had ' , $stats->count() . " new signups this week :tada:",
+                ]
+            ]
+        ]);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace App\Console;
 
+use App\Console\Commands\Reports\Weekly\SignupStatsReport;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 final class Kernel extends ConsoleKernel
 {
-    protected function schedule(Schedule $schedule): void {}
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command(SignupStatsReport::class)->weeklyOn(
+            dayOfWeek: 'friday',
+            time: '09:00',
+        );
+    }
 
     protected function commands(): void
     {

--- a/app/Listeners/Authentication/RegisterSignupStat.php
+++ b/app/Listeners/Authentication/RegisterSignupStat.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners\Authentication;
+
+use App\Stats\SignupStats;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+final class RegisterSignupStat implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function handle(Registered $event): void
+    {
+        SignupStats::increase();
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Listeners\Authentication\RegisterSignupStat;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -13,6 +14,7 @@ final class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+            RegisterSignupStat::class,
         ],
     ];
 }

--- a/app/Stats/SignupStats.php
+++ b/app/Stats/SignupStats.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Stats;
+
+use Spatie\Stats\BaseStats;
+
+final class SignupStats extends BaseStats
+{
+    public function getName(): string
+    {
+        return 'signups';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "laravel/tinker": "^2.8.2",
         "spatie/laravel-csp": "^2.8.3",
         "spatie/laravel-responsecache": "^7.4.10",
-        "spatie/laravel-slack-alerts": "^1.3"
+        "spatie/laravel-slack-alerts": "^1.3",
+        "spatie/laravel-stats": "^2.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23.0",

--- a/database/migrations/2023_11_10_235452_create_stats_tables.php
+++ b/database/migrations/2023_11_10_235452_create_stats_tables.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStatsTables extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stats_events', static function (Blueprint $table): void {
+            $table->id();
+
+            $table->string('name');
+            $table->string('type');
+            $table->bigInteger('value');
+
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
This PR adds the Spatie Laravel Stats package, that lets you track specific statistics in your applications. This also includes a sign up statistic so when the Laravel registered event is triggered the statistic increases. A command is scheduled once a week on a friday to send a slack alert with the latest count of user sign ups for the past week.